### PR TITLE
Update RegisterRoutePatterns.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Laravel provides a convenient way to validate URL parameters using [patterns](ht
 - hash (`[a-z0-9]+`)
 - uuid (`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 - slug (`[a-z0-9-]+`)
-- token (`[a-zA-Z0-9]{60}`)
+- token (`[a-zA-Z0-9]{64}`)
 
 So forget about writing:
 

--- a/src/Routers/RegisterRoutePatterns.php
+++ b/src/Routers/RegisterRoutePatterns.php
@@ -20,7 +20,7 @@ class RegisterRoutePatterns extends Router
         $this->router->pattern('hash', '[a-z0-9]+');
         $this->router->pattern('uuid', '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}');
         $this->router->pattern('slug', '[a-z0-9-]+');
-        $this->router->pattern('token', '[a-zA-Z0-9]{60}');
+        $this->router->pattern('token', '[a-zA-Z0-9]{64}');
 
         // Allow full domain routing by including dots in the domain regex pattern. Same
         // use-case as subdomains, only this enables you to handle i.e. www.site1.com

--- a/tests/Unit/RoutePatternTest.php
+++ b/tests/Unit/RoutePatternTest.php
@@ -54,7 +54,7 @@ class RoutePatternTest extends TestCase
     public function it maps the token pattern() : void
     {
         $this->assertRoutePattern(function (Router $registrar) {
-            $registrar->shouldReceive('pattern')->once()->with('token', '[a-zA-Z0-9]{60}');
+            $registrar->shouldReceive('pattern')->once()->with('token', '[a-zA-Z0-9]{64}');
         });
     }
 


### PR DESCRIPTION
Tokens in laravel are 64 characters not 60.

## PR Type

What kind of pull request is this? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Extend feature (non-breaking change which extends existing functionality)
- [ ] Change feature (non-breaking change which either changes or refactors existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## What does it change?

If I reset a password the token will 404 because of the character limit - 60 instead of 64.

## Why this PR?

Because without it I can't reset passwords in laravel 5.8 with this package.

## How has this been tested?

Tested and debugged on both hosted and local Laravel 5.8.

## Checklist

To facilitate merging your change and the approval of this PR, please make sure you've reviewed and applied the following:

- This PR addresses exactly one issue
- All changes were made in a fork of this project (preferably also in a separate branch)
- It follows the code style of this project
- Tests were added to cover the changes
- All previously existing tests still pass
- If the change to the code requires a change to the documentation, it has been updated accordingly

If you're unsure about any of these, don't hesitate to ask. We're here to help!
